### PR TITLE
Seamlessly switch prefix

### DIFF
--- a/src/features/warnAboutUnconventionalComments.js
+++ b/src/features/warnAboutUnconventionalComments.js
@@ -1,35 +1,22 @@
 import { state } from '../state.js'
 import { UNCONVENTIONAL_WARNING } from '../settings.js'
-import { semanticLabels } from '../labels.js'
 import { selectors, classes } from '../selectors.js'
-
-const validPrefixes = Object.values(semanticLabels).flatMap(({ text }) => [
-  `**${text}:** `,
-  `**${text} (non-blocking):** `,
-])
-
-const hasConventionalCommentPrefix = (comment) => {
-  for (const validPrefix of validPrefixes) {
-    if (comment.startsWith(validPrefix)) {
-      return true
-    }
-  }
-  return false
-}
+import { getConventionalCommentPrefix } from '../utils.js'
 
 export const warnAboutUnconventionalComments = ({ controls, contentEditable }) => {
   const editor = contentEditable.closest(selectors.editor)
-  
+
   if (editor.classList.contains(classes.bitbucket.reply)) {
     return // don't warn on replies
   }
-  
+
   const nonCancelButtons = controls.querySelectorAll(selectors.nonCancelButton)
 
   const handleClick = (e) => {
+    const hasConventionalCommentPrefix = !!getConventionalCommentPrefix(contentEditable.innerText)
     if (
-      !hasConventionalCommentPrefix(contentEditable.innerText) &&
-      !confirm('Missing conventional comment prefix. Send anyway?')
+      !hasConventionalCommentPrefix &&
+      !confirm('Missing or invalid conventional comment prefix. Send anyway?')
     ) {
       e.stopImmediatePropagation()
     }


### PR DESCRIPTION
Opening issue #4 rubberducked me into this fix. Realized that we just need to keep mimicking human behavior to play nice with Bitbucket's React lifecycle. IRL you would select the existing part and either delete or overwrite it, and since we have access to pasting, we can simply select the old prefix and paste over it.

Fixes #4.